### PR TITLE
global: add copyright everywhere

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,15 @@
+..
+    This file is part of Inspire-Magpie.
+    Copyright (c) 2016 CERN
+
+    Inspire-Magpie is a free software; you can redistribute it and/or modify it
+    under the terms of the MIT License; see LICENSE file for
+    more details.
+
+
+Authors
+=======
+
+- Jan Stypka <jan.stypka@cern.ch>
+- Eamonn Maguire <eamonnmag@gmail.com>
+- Jan Aage Lavik <jan.age.lavik@cern.ch>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
 include *.md
 include LICENSE
 recursive-include data *.gensim

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# inspire-magpie
+<!---
+  This file is part of Inspire-Magpie.
+  Copyright (c) 2016 CERN
+
+  Inspire-Magpie is a free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for
+  more details.
+-->
+
+# Inspire-Magpie
 
 A wrapper around [magpie](https://github.com/inspirehep/magpie) for Inspire that provides trained models and functions to learn from the High Energy Physics corpus.
 
@@ -16,6 +25,7 @@ $ pip install .
 
 # Usage
 There exists a UI and REST API based on [Flask](http://flask.pocoo.org/) that you can run with:
+
 ```shell
 $ python wsgi.py
 ```

--- a/inspire_magpie/__init__.py
+++ b/inspire_magpie/__init__.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""Custom exceptions.
+
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
 from __future__ import absolute_import, print_function
 
 from flask import Flask

--- a/inspire_magpie/api.py
+++ b/inspire_magpie/api.py
@@ -1,3 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""API.
+
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
 import os
 
 import numpy as np

--- a/inspire_magpie/config.py
+++ b/inspire_magpie/config.py
@@ -1,3 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""Configuration.
+
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
 import os
 import sys
 

--- a/inspire_magpie/labels.py
+++ b/inspire_magpie/labels.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""Labels.
+
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
+
 def get_labels(n):
     if n == 14:
         return get_categories()

--- a/inspire_magpie/rest.py
+++ b/inspire_magpie/rest.py
@@ -1,3 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""REST Blueprint.
+
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
 import os
 import time
 

--- a/inspire_magpie/static/js/utils.js
+++ b/inspire_magpie/static/js/utils.js
@@ -1,5 +1,10 @@
 /**
- * Created by eamonnmaguire on 23/02/2016.
+ * This file is part of Inspire-Magpie.
+ * Copyright (c) 2016 CERN
+ *
+ * Inspire-Magpie is a free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for
+ * more details.
  */
 
 var magpie_utils = (function(){

--- a/inspire_magpie/static/style.css
+++ b/inspire_magpie/static/style.css
@@ -1,3 +1,12 @@
+/*
+ * This file is part of Inspire-Magpie.
+ * Copyright (c) 2016 CERN
+ *
+ * Inspire-Magpie is a free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for
+ * more details.
+ */
+
 body, html {
     width: 100%;
     height: 100%;

--- a/inspire_magpie/templates/magpie/base.html
+++ b/inspire_magpie/templates/magpie/base.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/inspire_magpie/templates/magpie/components/extractor_form.html
+++ b/inspire_magpie/templates/magpie/components/extractor_form.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 <div align="left">
     <div id="progress-view" class="hidden">
         <div class="spinner">

--- a/inspire_magpie/templates/magpie/components/word2vec_form.html
+++ b/inspire_magpie/templates/magpie/components/word2vec_form.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 <form method="POST" class="form-horizontal text-left" align="left" action="/word2vec">
     <a href="/">
         <input type="hidden" name="domain" value="hep"/>

--- a/inspire_magpie/templates/magpie/extractor.html
+++ b/inspire_magpie/templates/magpie/extractor.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 {% extends "magpie/base.html" %}
 {%- block content -%}
     <div class="form-container" align="center">

--- a/inspire_magpie/templates/magpie/results.html
+++ b/inspire_magpie/templates/magpie/results.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 {% extends "magpie/base.html" %}
 {%- block content -%}
     <div class="form-container" align="center">

--- a/inspire_magpie/templates/magpie/thanks.html
+++ b/inspire_magpie/templates/magpie/thanks.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 {% extends "magpie/base.html" %}
 {%- block content -%}
     <div class="form-container" align="center">

--- a/inspire_magpie/templates/magpie/word2vec.html
+++ b/inspire_magpie/templates/magpie/word2vec.html
@@ -1,3 +1,12 @@
+{#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+#}
+
 {% extends "magpie/base.html" %}
 {%- block content -%}
     <div class="form-container" align="center">

--- a/inspire_magpie/ui.py
+++ b/inspire_magpie/ui.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""UI Blueprint.
+
+.. codeauthor:: Eamonn Maguire <eamonnmag@gmail.com>
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
 from flask import Blueprint, render_template, redirect, request, url_for
 
 from .api import get_word_vector, predict_labels
@@ -27,7 +45,6 @@ def extractor():
 
 @blueprint.route('/extract-feedback', methods=['POST'])
 def extract_feedback():
-    print request.form
     text = request.form.get('text', '')
 
     return redirect('/thanks')

--- a/inspire_magpie/version.py
+++ b/inspire_magpie/version.py
@@ -1,8 +1,17 @@
-{#
+# -*- coding: utf-8 -*-
+#
 # This file is part of Inspire-Magpie.
 # Copyright (c) 2016 CERN
 #
 # Inspire-Magpie is a free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for
 # more details.
-#}
+
+"""Version information for Inspire-Magpie.
+
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
+__version__ = "0.1.0"

--- a/inspire_magpie/wsgi.py
+++ b/inspire_magpie/wsgi.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""WSGI app.
+
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
+"""
+
+from __future__ import absolute_import, print_function
+
 import logging
 
 from inspire_magpie import application

--- a/setup.py
+++ b/setup.py
@@ -1,102 +1,63 @@
-"""A setuptools based setup module.
-See:
-https://packaging.python.org/en/latest/distributing.html
-https://github.com/pypa/sampleproject
+# -*- coding: utf-8 -*-
+#
+# This file is part of Inspire-Magpie.
+# Copyright (c) 2016 CERN
+#
+# Inspire-Magpie is a free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""Setup for Inspire-Magpie.
+
+.. codeauthor:: Jan Stypka <jan.stypka@cern.ch>
+.. codeauthor:: Eamonn Maguire <eamonnmag@gmail.com>
+.. codeauthor:: Jan Aage Lavik <jan.age.lavik@cern.ch>
 """
 
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-# To use a consistent encoding
+from __future__ import absolute_import, print_function
+
+import os
+
 from codecs import open
-from os import path
+from setuptools import setup, find_packages
 
-# here = path.abspath(path.dirname(__file__))
 
-# Get the long description from the README file
-# with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-#     long_description = f.read()
+# Get the version string. Cannot be done with import!
+g = {}
+with open(os.path.join('inspire_magpie', 'version.py'), 'rt') as fp:
+    exec(fp.read(), g)
+    version = g['__version__']
+
+readme = open('README.md').read()
 
 setup(
     name='inspire-magpie',
-
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1',
-
+    version=version,
     description='Magpie wrapper for Inspire',
-    # long_description=long_description,
-
-    # The project's main homepage.
+    long_description=readme,
     url='https://github.com/inspirehep/inspire-magpie',
-
-    # Author details
-    author='Jan Stypka',
-    author_email='jan.stypka@cern.ch',
-
-    # Choose your license
+    author='CERN',
+    author_email='admin@inspirehep.net',
     license='MIT',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
         'Development Status :: 4 - Beta',
-
         'Topic :: Text Processing',
-
-        # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: MIT License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
         # 'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         # 'Programming Language :: Python :: 3',
         # 'Programming Language :: Python :: 3.4',
     ],
-
-    # What does your project relate to?
     keywords='automatic keyword keyphrase extraction text classification inspire hep',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
+    packages=find_packages(),
     install_requires=[
         'magpie',
         'flask',
         'gensim',
         'h5py',
     ],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    # extras_require={
-    #     'dev': ['check-manifest'],
-    #     'test': ['coverage'],
-    # },
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-    # package_data={
-    #     '': ['data/*/*'],
-    # },
     include_package_data=True,
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     data_files=[('inspire_magpie_data', [
         'data/scaler.pickle',
         'data/word2vec.gensim',
@@ -108,13 +69,4 @@ setup(
     ]), ('inspire_magpie_data/categories', [
         'data/categories/model.pickle',
     ])],
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    # entry_points={
-    #     'console_scripts': [
-    #         'sample=sample:main',
-    #     ],
-    # },
 )


### PR DESCRIPTION
- Adds copyright information to all files.
- Updates setup.py.

@eamonnmag and @jstypka can you go over this and let me know if it is okay. I added codeauthor to every Python file listing who has contributed to it.
